### PR TITLE
Check for imgUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Extended by Flobacher to be able to use with spritesheets and in AngularJS Appli
 ## Why?
 Linking to an external SVG on a page (via `object`, `embed`, `iframe`, `img`, CSS `background-image`) usually only allows you to display the SVG 'as is'. To unlock the full potential of SVG, including full element-level CSS styling and evaluation of embedded JavaScript, the markup of the SVG must be included directly in the DOM.
 
-Maintaining a bunch of inline SVG on your pages isn't anyone's idea of good time, so **SVGInjector** lets you specifiy external SVGs and embeds the contents directly into the DOM alongside your HTML.
+Maintaining a bunch of inline SVG on your pages isn't anyone's idea of good time, so **SVGInjector** lets you specify external SVGs and embeds the contents directly into the DOM alongside your HTML.
 
 ## How?
 * Any DOM element or array of elements (recommended are `svg`-tags for clarity or `img`-tags if you need support for fallback pngs, but there are no technical limitations), passed to **SVGInjector** that contains a `data-src` attribute will be replaced with the full SVG markup available via this URL inline. The async loaded SVG is also cached so multiple uses of an SVG only requires a single server request.

--- a/src/svg-injector.js
+++ b/src/svg-injector.js
@@ -214,12 +214,16 @@
         imgUrl = config.spritesheetURL + '#' + spriteId;
         // console.log('imgURL: ' + imgUrl);
       }
-      el.setAttribute('data-src', imgUrl);
 
-      var imgUrlSplitByFId = imgUrl.split('#');
-      if (imgUrlSplitByFId.length === 1) {
-        imgUrlSplitByFId.push('');
+      if (imgUrl) {
+        el.setAttribute('data-src', imgUrl);
+
+        var imgUrlSplitByFId = imgUrl.split('#');
+        if (imgUrlSplitByFId.length === 1) {
+          imgUrlSplitByFId.push('');
+        }
       }
+
       var fallbackUrl;
 
       // We can only inject SVG


### PR DESCRIPTION
Simple fix for `TypeError: Cannot read property 'split' of null` when SVGInjector encounters an inline SVG without a src/data-src