### PR TITLE
bugfix, replace element

### DIFF
--- a/src/svg-injector.js
+++ b/src/svg-injector.js
@@ -1040,15 +1040,15 @@
       var newElem,
           existingElem = svg.querySelector(type);
 
-      if (existingElem) { // remove
-        existingElem.parentNode.removeChild(existingElem);
-      }
-
       newElem = document.createElementNS(SVG_NS, type);
       newElem.appendChild(document.createTextNode(text));
       newElem.setAttribute('id', id);
 
       svg.insertBefore(newElem, insertBefore);
+      
+      if (existingElem) { // remove
+        existingElem.parentNode.removeChild(existingElem);
+      }
 
       return newElem;
     };


### PR DESCRIPTION
Do not remove existing element before insert. When the element to be replaced is the first child, it will is the same as `insertBefore`.